### PR TITLE
Updates plugin to check for rustfmt config file

### DIFF
--- a/RustFmt.py
+++ b/RustFmt.py
@@ -63,18 +63,17 @@ def first(iterable, condition = lambda x: True):
     return next((x for x in iterable if condition(x)), None)
 
 
-def append_config_path(view, args):
-    iterable = map(config_for_dir, walk_to_root(view.file_name()))
-    config = first(iterable, lambda x: x is not None)
-    if config is not None:
-        args += ['--config-path={}'.format(config)]
+def find_config_path(path):
+    return first(map(config_for_dir, walk_to_root(path)), lambda x: x is not None)
 
 
 def run_format(view, input, encoding):
-    args = to_list(settings_get(view, 'executable')) + ['--write-mode=display']
+    args = to_list(settings_get(view, 'executable')) + ['--write-mode', 'display']
 
     if settings_get(view, 'use_config_path'):
-        append_config_path(view, args)
+        config = find_config_path(view.file_name())
+        if config:
+            args += ['--config-path', config]
 
     proc = sub.Popen(
         args=args,

--- a/RustFmt.py
+++ b/RustFmt.py
@@ -63,13 +63,18 @@ def first(iterable, condition = lambda x: True):
     return next((x for x in iterable if condition(x)), None)
 
 
-def run_format(view, input, encoding):
-    args = to_list(settings_get(view, 'executable')) + ['--write-mode=display']
-
+def append_config_path(view, args):
     iterable = map(config_for_dir, walk_to_root(view.file_name()))
     config = first(iterable, lambda x: x is not None)
     if config is not None:
         args += ['--config-path={}'.format(config)]
+
+
+def run_format(view, input, encoding):
+    args = to_list(settings_get(view, 'executable')) + ['--write-mode=display']
+
+    if settings_get(view, 'use_config_path'):
+        append_config_path(view, args)
 
     proc = sub.Popen(
         args=args,

--- a/RustFmt.py
+++ b/RustFmt.py
@@ -71,7 +71,8 @@ def run_format(view, input, encoding):
     args = to_list(settings_get(view, 'executable')) + ['--write-mode', 'display']
 
     if settings_get(view, 'use_config_path'):
-        config = find_config_path(view.file_name())
+        path = view.file_name() or first(view.window().folders(), bool)
+        config = path and find_config_path(path)
         if config:
             args += ['--config-path', config]
 

--- a/RustFmt.sublime-settings
+++ b/RustFmt.sublime-settings
@@ -1,5 +1,11 @@
 {
+  // If true, Format Buffer will be run when a buffer is saved.
   "format_on_save": true,
+  // Can be a string (path) or a list (executable + args).
   "executable": "rustfmt",
+  // Whether to tell `rustfmt` to search for the TOML config in the current
+  // folder. For anonymous buffers, attempts to guess the current folder from
+  // the window. Off by default because at the time of writing, the default
+  // version of `rustfmt` doesn't support configs.
   "use_config_path": false
 }

--- a/RustFmt.sublime-settings
+++ b/RustFmt.sublime-settings
@@ -1,4 +1,5 @@
 {
   "format_on_save": true,
-  "executable": "rustfmt"
+  "executable": "rustfmt",
+  "use_config_path": false
 }


### PR DESCRIPTION
This pull request extends the plugin to look for a rustfmt.toml or .rustfmt.toml config file on the path from the current file to the root directory, so that project specific settings can be respected.